### PR TITLE
Fix deprecated warnings, cleanup fixtures

### DIFF
--- a/tests/cpp/core.cc
+++ b/tests/cpp/core.cc
@@ -125,16 +125,16 @@ CAF_TEST(local_peers) {
   auto core2 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
   anon_send(core1, atom::no_events::value);
   anon_send(core2, atom::no_events::value);
-  sched.run();
+  run();
   CAF_MESSAGE("connect a consumer (leaf) to core2");
   auto leaf = sys.spawn(consumer, filter_type{"b"}, core2);
   CAF_MESSAGE("core1: " << to_string(core1));
   CAF_MESSAGE("core2: " << to_string(core2));
   CAF_MESSAGE("leaf: " << to_string(leaf));
-  sched.run_once();
+  consume_message();
   expect((atom_value, filter_type),
          from(leaf).to(core2).with(join_atom::value, filter_type{"b"}));
-  sched.run();
+  run();
   // Initiate handshake between core1 and core2.
   self->send(core1, atom::peer::value, core2);
   expect((atom::peer, actor), from(self).to(core1).with(_, core2));
@@ -151,7 +151,7 @@ CAF_TEST(local_peers) {
     }
   );
   CAF_MESSAGE("run handshake between peers");
-  sched.run();
+  run();
   // Check if core1 & core2 both report each other as peered.
   CAF_MESSAGE("query peer information from core1");
   sched.inline_next_enqueue();
@@ -178,12 +178,12 @@ CAF_TEST(local_peers) {
   CAF_MESSAGE("spin up driver on core1");
   auto d1 = sys.spawn(driver, core1, false);
   CAF_MESSAGE("driver: " << to_string(d1));
-  run_exhaustively();
+  run();
   CAF_MESSAGE("check log of the consumer after the driver is done");
   using buf = std::vector<element_type>;
   self->send(leaf, atom::get::value);
   sched.prioritize(leaf);
-  sched.run_once();
+  consume_message();
   self->receive(
     [](const buf& xs) {
       buf expected{{"b", true}, {"b", false}, {"b", true}, {"b", false}};
@@ -197,11 +197,11 @@ CAF_TEST(local_peers) {
          from(_).to(core1).with(_, _, _, _));
   expect((atom::publish, atom::local, topic, data),
          from(core1).to(core2).with(_, _, topic("b"), data{true}));
-  sched.run();
+  run();
   CAF_MESSAGE("check log of the consumer again");
   self->send(leaf, atom::get::value);
   sched.prioritize(leaf);
-  sched.run_once();
+  consume_message();
   self->receive(
     [](const buf& xs) {
       buf expected{{"b", true}, {"b", false}, {"b", true},
@@ -211,7 +211,7 @@ CAF_TEST(local_peers) {
   );
   CAF_MESSAGE("unpeer core1 from core2");
   anon_send(core1, atom::unpeer::value, core2);
-  sched.run();
+  run();
   CAF_MESSAGE("check whether both core1 and core2 report no more peers");
   sched.inline_next_enqueue();
   self->request(core1, infinite, atom::get::value, atom::peer::value).receive(
@@ -235,8 +235,6 @@ CAF_TEST(local_peers) {
   anon_send_exit(core1, exit_reason::user_shutdown);
   anon_send_exit(core2, exit_reason::user_shutdown);
   anon_send_exit(leaf, exit_reason::user_shutdown);
-  sched.run();
-  sched.inline_all_enqueues();
 }
 
 // Simulates a simple triangle setup where core1 peers with core2, and core2
@@ -251,16 +249,16 @@ CAF_TEST(triangle_peering) {
   anon_send(core1, atom::no_events::value);
   anon_send(core2, atom::no_events::value);
   anon_send(core3, atom::no_events::value);
-  sched.run();
+  run();
   // Connect a consumer (leaf) to core1 (this consumer never receives data,
   // because data isn't forwarded to local subscribers).
   auto leaf1 = sys.spawn(consumer, filter_type{"b"}, core1);
   // Connect a consumer (leaf) to core2.
   auto leaf2 = sys.spawn(consumer, filter_type{"b"}, core2);
-  sched.run();
+  run();
   // Connect a consumer (leaf) to core3.
   auto leaf3 = sys.spawn(consumer, filter_type{"b"}, core3);
-  sched.run();
+  run();
   // Initiate handshake between core1 and core2.
   self->send(core1, atom::peer::value, core2);
   expect((atom::peer, actor), from(self).to(core1).with(_, core2));
@@ -279,7 +277,7 @@ CAF_TEST(triangle_peering) {
   // Step #1: core1  --->    ('peer', filter_type)    ---> core2
   expect((atom::peer, filter_type, actor),
          from(core1).to(core2).with(_, filter_type{"a", "b", "c"}, core1));
-  sched.run();
+  run();
   // Initiate handshake between core2 and core3.
   self->send(core2, atom::peer::value, core3);
   expect((atom::peer, actor), from(self).to(core2).with(_, core3));
@@ -297,7 +295,7 @@ CAF_TEST(triangle_peering) {
     }
   );
   // Perform further handshake steps.
-  sched.run();
+  run();
   // Check if all cores properly report peering setup.
   CAF_MESSAGE("query peer information from core1");
   sched.inline_next_enqueue();
@@ -336,14 +334,14 @@ CAF_TEST(triangle_peering) {
   // Spin up driver on core1.
   auto d1 = sys.spawn(driver, core1, false);
   CAF_MESSAGE("d1: " << to_string(d1));
-  run_exhaustively();
+  run();
   // Check log of the consumers.
   using buf = std::vector<element_type>;
   buf expected{{"b", true}, {"b", false}, {"b", true}, {"b", false}};
   for (auto& leaf : {leaf2, leaf3}) {
     self->send(leaf, atom::get::value);
     sched.prioritize(leaf);
-    sched.run_once();
+    consume_message();
     self->receive(
       [&](const buf& xs) {
         CAF_REQUIRE_EQUAL(xs, expected);
@@ -353,7 +351,7 @@ CAF_TEST(triangle_peering) {
   // Make sure leaf1 never received any data.
   self->send(leaf1, atom::get::value);
   sched.prioritize(leaf1);
-  sched.run_once();
+  consume_message();
   self->receive(
     [&](const buf& xs) {
       CAF_REQUIRE(xs.empty());
@@ -364,8 +362,6 @@ CAF_TEST(triangle_peering) {
   anon_send_exit(core1, exit_reason::user_shutdown);
   anon_send_exit(core2, exit_reason::user_shutdown);
   anon_send_exit(core3, exit_reason::user_shutdown);
-  sched.run();
-  sched.inline_all_enqueues();
 }
 
 // Simulates a simple setup where core1 peers with core2 and starts sending
@@ -385,15 +381,15 @@ CAF_TEST(sequenced_peering) {
   anon_send(core1, atom::no_events::value);
   anon_send(core2, atom::no_events::value);
   anon_send(core3, atom::no_events::value);
-  sched.run();
+  run();
   // Connect a consumer (leaf) to core2.
   auto leaf1 = sys.spawn(consumer, filter_type{"b"}, core2);
   CAF_MESSAGE(CAF_ARG(leaf1));
-  sched.run();
+  run();
   // Connect a consumer (leaf) to core3.
   auto leaf2 = sys.spawn(consumer, filter_type{"b"}, core3);
   CAF_MESSAGE(CAF_ARG(leaf2));
-  sched.run();
+  run();
   // Initiate handshake between core1 and core2.
   self->send(core1, atom::peer::value, core2);
   expect((atom::peer, actor), from(self).to(core1).with(_, core2));
@@ -411,17 +407,17 @@ CAF_TEST(sequenced_peering) {
   );
   expect((atom::peer, filter_type, actor),
          from(core1).to(core2).with(_, filter_type{"a", "b", "c"}, core1));
-  sched.run();
+  run();
   CAF_MESSAGE("spin up driver and transmit first half of the data");
   auto d1 = sys.spawn(driver, core1, true);
   CAF_MESSAGE(CAF_ARG(d1));
-  run_exhaustively();
+  run();
   // Check log of the consumer on core2.
   using buf = std::vector<element_type>;
   buf expected{{"b", true}, {"b", false}, {"b", true}, {"b", false}};
   self->send(leaf1, atom::get::value);
   sched.prioritize(leaf1);
-  sched.run_once();
+  consume_message();
   self->receive(
     [&](const buf& xs) {
       CAF_REQUIRE_EQUAL(xs, expected);
@@ -429,7 +425,7 @@ CAF_TEST(sequenced_peering) {
   );
   CAF_MESSAGE("kill core2");
   anon_send_exit(core2, exit_reason::user_shutdown);
-  sched.run();
+  run();
   CAF_MESSAGE("make sure core1 sees no peer anymore");
   sched.inline_next_enqueue();
   self->request(core1, infinite, atom::get::value, atom::peer::value).receive(
@@ -458,10 +454,10 @@ CAF_TEST(sequenced_peering) {
   // Step #1: core1  --->    ('peer', filter_type)    ---> core3
   expect((atom::peer, filter_type, actor),
          from(core1).to(core3).with(_, filter_type{"a", "b", "c"}, core1));
-  sched.run();
+  run();
   CAF_MESSAGE("restart driver and send second half of the data");
   anon_send(d1, restart_atom::value);
-  run_exhaustively();
+  run();
   // Check log of the consumer on core3.
   sched.inline_next_enqueue();
   self->request(leaf2, infinite, atom::get::value).receive(
@@ -476,8 +472,6 @@ CAF_TEST(sequenced_peering) {
   CAF_MESSAGE("Shutdown core actors.");
   anon_send_exit(core1, exit_reason::user_shutdown);
   anon_send_exit(core3, exit_reason::user_shutdown);
-  sched.run();
-  sched.inline_all_enqueues();
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()
@@ -498,11 +492,7 @@ struct error_signaling_fixture : base_fixture {
     core2 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
     CAF_MESSAGE(CAF_ARG(core2));
     anon_send(core2, atom::no_events::value);
-    sched.run();
-  }
-
-  ~error_signaling_fixture() {
-    sched.inline_all_enqueues();
+    run();
   }
 };
 
@@ -552,7 +542,7 @@ CAF_TEST(failed_handshake_stage0) {
   self->send(core1, atom::peer::value, core2);
   anon_send_exit(core2, exit_reason::kill);
   expect((atom::peer, actor), from(self).to(core1).with(_, core2));
-  sched.run();
+  run();
   BROKER_CHECK_LOG(es.poll(), ec::peer_unavailable);
 }
 
@@ -564,7 +554,7 @@ CAF_TEST(failed_handshake_stage1) {
   expect((atom::peer, filter_type, actor),
          from(core2).to(core1).with(_, filter_type{"a", "b", "c"}, core2));
   anon_send_exit(core2, exit_reason::kill);
-  sched.run();
+  run();
   BROKER_CHECK_LOG(es.poll(), sc::peer_added, sc::peer_lost);
 }
 
@@ -580,7 +570,7 @@ CAF_TEST(failed_handshake_stage2) {
   CAF_MESSAGE("have core1 handle the pending handshake");
   expect((open_stream_msg), from(_).to(core1).with(_, _, _, _, _, false));
   CAF_MESSAGE("run remaining messages");
-  sched.run();
+  run();
   CAF_MESSAGE("check log of the event subscriber");
   BROKER_CHECK_LOG(es.poll(), sc::peer_added, sc::peer_lost);
 }
@@ -595,7 +585,7 @@ CAF_TEST(failed_handshake_stage3) {
   expect((open_stream_msg), from(_).to(core2).with(_, core1, _, _, false));
   anon_send_exit(core2, exit_reason::kill);
   expect((open_stream_msg), from(_).to(core1).with(_, core2, _, _, false));
-  sched.run();
+  run();
   BROKER_CHECK_LOG(es.poll(), sc::peer_added, sc::peer_lost);
 }
 
@@ -603,43 +593,41 @@ CAF_TEST(failed_handshake_stage3) {
 CAF_TEST(unpeer_core1_from_core2) {
   CAF_MESSAGE("initiate handshake between core1 and core2");
   anon_send(core1, atom::peer::value, core2);
-  sched.run();
+  run();
   CAF_MESSAGE("unpeer core1 and core2");
   anon_send(core1, atom::unpeer::value, core2);
-  sched.run();
+  run();
   BROKER_CHECK_LOG(es.poll(), sc::peer_added, sc::peer_removed);
   CAF_MESSAGE("unpeering again emits peer_invalid");
   anon_send(core1, atom::unpeer::value, core2);
-  sched.run();
+  run();
   BROKER_CHECK_LOG(es.poll(), ec::peer_invalid);
   CAF_MESSAGE("unpeering from an unconnected network emits peer_invalid");
   anon_send(core1, atom::unpeer::value, network_info{"localhost", 8080});
-  sched.run();
+  run();
   BROKER_CHECK_LOG(es.poll(), ec::peer_invalid);
   anon_send_exit(core1, exit_reason::user_shutdown);
   anon_send_exit(core2, exit_reason::user_shutdown);
-  sched.run();
 }
 
 // Checks emitted events in case a remote peer unpeers.
 CAF_TEST(unpeer_core2_from_core1) {
   // Initiate handshake between core1 and core2.
   anon_send(core2, atom::peer::value, core1);
-  sched.run();
+  run();
   anon_send(core2, atom::unpeer::value, core1);
-  sched.run();
+  run();
   BROKER_CHECK_LOG(es.poll(), sc::peer_added, sc::peer_lost);
   // Try unpeering again, this time on core1.
   anon_send(core1, atom::unpeer::value, core2);
-  sched.run();
+  run();
   BROKER_CHECK_LOG(es.poll(), ec::peer_invalid);
   // Try unpeering from an unconnected network address.
   anon_send(core1, atom::unpeer::value, network_info{"localhost", 8080});
-  sched.run();
+  run();
   BROKER_CHECK_LOG(es.poll(), ec::peer_invalid);
   anon_send_exit(core1, exit_reason::user_shutdown);
   anon_send_exit(core2, exit_reason::user_shutdown);
-  sched.run();
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()
@@ -703,8 +691,6 @@ CAF_TEST(remote_peers_setup1) {
   anon_send_exit(core2, exit_reason::user_shutdown);
   anon_send_exit(leaf, exit_reason::user_shutdown);
   exec_all();
-  mars.sched.inline_all_enqueues();
-  earth.sched.inline_all_enqueues();
 }
 
 // Setup: driver -> mars.core -> earth.core -> leaf
@@ -754,7 +740,7 @@ CAF_TEST(remote_peers_setup2) {
   using buf = std::vector<element_type>;
   mars.self->send(leaf, atom::get::value);
   mars.sched.prioritize(leaf);
-  mars.sched.run_once();
+  mars.consume_message();
   mars.self->receive(
     [](const buf& xs) {
       buf expected{{"b", true}, {"b", false}, {"b", true}, {"b", false}};
@@ -766,8 +752,6 @@ CAF_TEST(remote_peers_setup2) {
   anon_send_exit(core2, exit_reason::user_shutdown);
   anon_send_exit(leaf, exit_reason::user_shutdown);
   exec_all();
-  mars.sched.inline_all_enqueues();
-  earth.sched.inline_all_enqueues();
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()

--- a/tests/cpp/publisher.cc
+++ b/tests/cpp/publisher.cc
@@ -88,7 +88,7 @@ CAF_TEST(blocking_publishers) {
   self->send(core1, atom::peer::value, core2);
   // Connect a consumer (leaf) to core2, which receives only a subset of 'a'.
   auto leaf = sys.spawn(consumer, filter_type{"a/b"}, core2);
-  sched.run();
+  run();
   { // Lifetime scope of our publishers.
     // Spin up two publishers: one for "a" and one for "a/b".
     auto pub1 = ep.make_publisher("a");
@@ -97,25 +97,25 @@ CAF_TEST(blocking_publishers) {
     pub2.drop_all_on_destruction();
     auto d1 = pub1.worker();
     auto d2 = pub2.worker();
-    sched.run();
+    run();
     // Data flows from our publishers to core1 to core2 and finally to leaf.
     using buf = std::vector<value_type>;
     // First, set of published messages gets filtered out at core2.
     pub1.publish(0);
-    sched.run_dispatch_loop();
+    run();
     // Second, set of published messages gets delivered to leaf.
     pub2.publish(true);
-    sched.run_dispatch_loop();
+    run();
     // Third, set of published messages gets again filtered out at core2.
     pub1.publish({1, 2, 3});
-    sched.run();
+    run();
     // Fourth, set of published messages gets delivered to leaf again.
     pub2.publish({false, true});
-    sched.run();
+    run();
     // Check log of the consumer.
     self->send(leaf, atom::get::value);
     sched.prioritize(leaf);
-    sched.run_once();
+    consume_message();
     self->receive(
       [](const buf& xs) {
         buf expected{{"a/b", true}, {"a/b", false}, {"a/b", true}};
@@ -128,8 +128,6 @@ CAF_TEST(blocking_publishers) {
   anon_send_exit(core1, exit_reason::user_shutdown);
   anon_send_exit(core2, exit_reason::user_shutdown);
   anon_send_exit(leaf, exit_reason::user_shutdown);
-  sched.run();
-  sched.inline_all_enqueues();
 }
 
 CAF_TEST(nonblocking_publishers) {
@@ -144,7 +142,7 @@ CAF_TEST(nonblocking_publishers) {
   self->send(core1, atom::peer::value, core2);
   // Connect a consumer (leaf) to core2.
   auto leaf = sys.spawn(consumer, filter_type{"b"}, core2);
-  sched.run_dispatch_loop(credit_round_interval);
+  run();
   // publish_all uses thread communication which would deadlock when using our
   // test_scheduler. We avoid this by pushing the call to publish_all to its
   // own thread.
@@ -168,11 +166,11 @@ CAF_TEST(nonblocking_publishers) {
     }
   );
   // Communication is identical to the driver-driven test in test/cpp/core.cc
-  sched.run_dispatch_loop(credit_round_interval);
+  run();
   // Check log of the consumer.
   self->send(leaf, atom::get::value);
   sched.prioritize(leaf);
-  sched.run_once();
+  consume_message();
   self->receive(
     [](const buf_type& xs) {
       buf_type expected{{"b", true}, {"b", false}, {"b", true}, {"b", false}};
@@ -184,8 +182,6 @@ CAF_TEST(nonblocking_publishers) {
   anon_send_exit(core1, exit_reason::user_shutdown);
   anon_send_exit(core2, exit_reason::user_shutdown);
   anon_send_exit(leaf, exit_reason::user_shutdown);
-  sched.run();
-  sched.inline_all_enqueues();
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()

--- a/tests/cpp/status_subscriber.cc
+++ b/tests/cpp/status_subscriber.cc
@@ -52,13 +52,13 @@ CAF_TEST_FIXTURE_SCOPE(status_subscriber_tests, fixture)
 CAF_TEST(base_tests) {
   auto sub1 = ep.make_status_subscriber(true);
   auto sub2 = ep.make_status_subscriber(false);
-  sched.run();
+  run();
   CAF_REQUIRE_EQUAL(sub1.available(), 0u);
   CAF_REQUIRE_EQUAL(sub2.available(), 0u);
   CAF_MESSAGE("test error event");
   ::broker::error e1 = ec::type_clash;
   push(e1);
-  sched.run();
+  run();
   CAF_REQUIRE_EQUAL(sub1.available(), 1u);
   CAF_REQUIRE_EQUAL(sub1.get(), e1);
   CAF_REQUIRE_EQUAL(sub2.available(), 1u);
@@ -66,14 +66,12 @@ CAF_TEST(base_tests) {
   CAF_MESSAGE("test status event");
   auto s1 = status::make<sc::unspecified>("foobar");;
   push(s1);
-  sched.run();
+  run();
   CAF_REQUIRE_EQUAL(sub1.available(), 1u);
   CAF_REQUIRE_EQUAL(sub1.get(), s1);
   CAF_REQUIRE_EQUAL(sub2.available(), 0u);
   CAF_MESSAGE("shutdown");
   anon_send_exit(ep.core(), exit_reason::user_shutdown);
-  sched.run();
-  sched.inline_all_enqueues();
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()

--- a/tests/test.hpp
+++ b/tests/test.hpp
@@ -56,13 +56,19 @@ class base_fixture {
 public:
   using scheduler_type = caf::scheduler::test_coordinator;
 
-  base_fixture(bool fake_network = false);
+  explicit base_fixture(bool fake_network = false);
+
+  virtual ~base_fixture();
 
   broker::endpoint ep;
   caf::actor_system& sys;
   caf::scoped_actor self;
   scheduler_type& sched;
   caf::timespan credit_round_interval;
+
+  void run();
+
+  void consume_message();
 
 private:
   static broker::configuration make_config(bool fake_network);


### PR DESCRIPTION
Recent CAF master improved and simplified its testing API. However, several functions got deprecated. This PR fixes all deprecated warnings and also cleans up a few redundancies in Broker's test code.

Note: the `core` unit test fails now without this patch. This is because the old code pretty much happened to work by accident (one place called `sched.run()` where it should've called `run_exhaustively()`, but it worked anyway because the old testing DSL advanced time a bit differently).