### PR TITLE
Make blocking flags available to Python wrapper

### DIFF
--- a/bindings/python/broker/__init__.py
+++ b/bindings/python/broker/__init__.py
@@ -118,11 +118,11 @@ class Subscriber:
     def fd(self):
         return self._subscriber.fd()
 
-    def add_topic(self, topic):
-        return self._subscriber.add_topic(_make_topic(topic))
+    def add_topic(self, topic, block=False):
+        return self._subscriber.add_topic(_make_topic(topic), block)
 
-    def remove_topic(self, topic):
-        return self._subscriber.remove_topic(_make_topic(topic))
+    def remove_topic(self, topic, block=False):
+        return self._subscriber.remove_topic(_make_topic(topic), block)
 
 class StatusSubscriber(_broker.Subscriber):
     def __init__(self, internal_subscriber):


### PR DESCRIPTION
The C++ API offers two flags that weren't available in the Python bindings. This PR adds them.