### PR TITLE
Remove unused warnings and variables

### DIFF
--- a/broker/detail/shared_subscriber_queue.hh
+++ b/broker/detail/shared_subscriber_queue.hh
@@ -58,6 +58,7 @@ public:
   // Inserts the range `[i, e)` into the queue.
   template <class Iter>
   void produce(size_t num, Iter i, Iter e) {
+    CAF_IGNORE_UNUSED(num);
     CAF_ASSERT(num == std::distance(i, e));
     guard_type guard{this->mtx_};
     if (this->xs_.empty())

--- a/broker/subscriber_base.hh
+++ b/broker/subscriber_base.hh
@@ -45,7 +45,7 @@ public:
 
   // --- constructors and destructors ------------------------------------------
 
-  subscriber_base(long max_qsize)
+  subscriber_base()
     : queue_(detail::make_shared_subscriber_queue<value_type>()) {
     // nop
   }

--- a/src/status_subscriber.cc
+++ b/src/status_subscriber.cc
@@ -32,8 +32,7 @@ behavior status_subscriber_worker(event_based_actor* self,
 
 } // namespace <anonymous>
 
-status_subscriber::status_subscriber(endpoint& ep, bool receive_statuses)
-  : super(std::numeric_limits<long>::max()) {
+status_subscriber::status_subscriber(endpoint& ep, bool receive_statuses) {
   worker_ = ep.system().spawn(status_subscriber_worker, receive_statuses,
                               queue_);
 }

--- a/src/subscriber.cc
+++ b/src/subscriber.cc
@@ -153,7 +153,7 @@ behavior subscriber_worker(stateful_actor<subscriber_worker_state>* self,
 } // namespace <anonymous>
 
 subscriber::subscriber(endpoint& e, std::vector<topic> ts, size_t max_qsize)
-  : super(max_qsize), ep_(e) {
+  : ep_(e) {
   BROKER_INFO("creating subscriber for topic(s)" << ts);
   worker_ = ep_.system().spawn(subscriber_worker, &ep_, queue_, std::move(ts),
                                max_qsize);


### PR DESCRIPTION
This PR removes warnings about unused warnings: by (1) silencing unused arguments in non-debug builds, and (2) actually removing an unused variable.