### PR TITLE
Update python.rst

### DIFF
--- a/doc/python.rst
+++ b/doc/python.rst
@@ -131,7 +131,7 @@ each other:
    * - ``subnet``
      - ``ipaddress.IPv4Network``/``ipaddress.IPv6Network``
    * - ``port``
-     - ``broker.Port(x, broker.Port.{TCP,UDP,ICMP})``
+     - ``broker.Port(x, broker.Port.{TCP,UDP,ICMP,Unknown})``
    * - ``vector``
      - ``list``
    * - ``set``


### PR DESCRIPTION
The documentation overlooked the existence of `broker.Port.Unknown`, which can be essential to sending data from dumb network sensors to bro.